### PR TITLE
[feat] HttpOnly cookie로 refresh token 전달

### DIFF
--- a/src/main/java/vote/vote_be/domain/auth/dto/internal/LoginResult.java
+++ b/src/main/java/vote/vote_be/domain/auth/dto/internal/LoginResult.java
@@ -1,0 +1,23 @@
+package vote.vote_be.domain.auth.dto.internal;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import vote.vote_be.domain.auth.dto.response.LoginResponse;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginResult {
+    // login 컨트롤러에서 사용할 정보를 전달하는 DTO
+    private LoginResponse loginResponse;
+    private String refreshToken;
+    private long refreshTtlSec;
+
+    public static LoginResult of(LoginResponse loginResponse, String refreshToken, long refreshTtlSec) {
+        LoginResult result = new LoginResult();
+        result.loginResponse = loginResponse;
+        result.refreshToken = refreshToken;
+        result.refreshTtlSec = refreshTtlSec;
+        return result;
+    }
+}

--- a/src/main/java/vote/vote_be/domain/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/vote/vote_be/domain/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,15 @@
+package vote.vote_be.domain.auth.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AccessTokenResponse {
+    private String accessToken;
+
+    public static AccessTokenResponse of(String accessToken) {
+        AccessTokenResponse response = new AccessTokenResponse();
+        response.accessToken = accessToken;
+        return response;
+    }
+}

--- a/src/main/java/vote/vote_be/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/vote/vote_be/domain/auth/dto/response/LoginResponse.java
@@ -14,16 +14,14 @@ public class LoginResponse {
     private Part part;
     private Team team;
     private String accessToken;
-    private String refreshToken;
 
-    public static LoginResponse of (Long userId, String name, Part part, Team team, String accessToken, String refreshToken) {
+    public static LoginResponse of (Long userId, String name, Part part, Team team, String accessToken) {
         LoginResponse loginResponse = new LoginResponse();
         loginResponse.userId = userId;
         loginResponse.name = name;
         loginResponse.part = part;
         loginResponse.team = team;
         loginResponse.accessToken = accessToken;
-        loginResponse.refreshToken = refreshToken;
 
         return loginResponse;
     }

--- a/src/main/java/vote/vote_be/global/config/SwaggerConfig.java
+++ b/src/main/java/vote/vote_be/global/config/SwaggerConfig.java
@@ -33,6 +33,7 @@ public class SwaggerConfig {
                         .scheme("bearer")
                         .bearerFormat("JWT"));
 
+
         return new OpenAPI()
                 .addServersItem(new Server().url(contextPath))
                 .info(info)

--- a/src/main/java/vote/vote_be/global/security/jwt/CookieUtil.java
+++ b/src/main/java/vote/vote_be/global/security/jwt/CookieUtil.java
@@ -1,0 +1,43 @@
+package vote.vote_be.global.security.jwt;
+import org.springframework.http.ResponseCookie;
+
+public final class CookieUtil {
+
+    public static final String REFRESH_COOKIE = "refresh_token";
+
+    private CookieUtil() {}
+
+    /* 리프레시 토큰 쿠키 생성 */
+    public static ResponseCookie buildRefreshCookie(
+            String value,
+            long maxAgeSec,
+            String domain,
+            boolean secure,
+            String sameSite
+    ) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(REFRESH_COOKIE, value)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(maxAgeSec);
+
+        if (domain != null && !domain.isBlank()) builder.domain(domain);
+        if (sameSite != null && !sameSite.isBlank()) builder.sameSite(sameSite);
+        builder.secure(secure);
+
+        return builder.build();
+    }
+
+    /* 리프레시 토큰 쿠키 제거 */
+    public static ResponseCookie deleteRefreshCookie(String domain, boolean secure, String sameSite) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(REFRESH_COOKIE, "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0);
+
+        if (domain != null && !domain.isBlank()) builder.domain(domain);
+        if (sameSite != null && !sameSite.isBlank()) builder.sameSite(sameSite);
+        builder.secure(secure);
+
+        return builder.build();
+    }
+}

--- a/src/main/java/vote/vote_be/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/vote/vote_be/global/security/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
 
         String token = tokenProvider.resolveToken(request);
-
         if (token != null) {
             try{
                 // Authentication 생성
@@ -42,18 +41,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
             } catch (ExpiredJwtException e) {
-                handleException(response, ErrorStatus.ACCESS_TOKEN_EXPIRED);
+                handleJwtException(response, ErrorStatus.ACCESS_TOKEN_EXPIRED);
                 return;
             } catch (SecurityException | MalformedJwtException |
                      UnsupportedJwtException | IllegalArgumentException e) {
-                handleException(response, ErrorStatus.TOKEN_INVALID);
+                handleJwtException(response, ErrorStatus.TOKEN_INVALID);
                 return;
             }
         }
         filterChain.doFilter(request, response);
     }
 
-    private void handleException(HttpServletResponse response, ErrorStatus status) throws IOException {
+    private void handleJwtException(HttpServletResponse response, ErrorStatus status) throws IOException {
         response.setStatus(status.getHttpStatus().value());
         response.setContentType("application/json;charset=UTF-8");
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #19

## 📝작업 내용

>  HttpOnly cookie로 refresh token 전달

- [x] 로그인시 HttpOnly cookie로 refresh token 전달
- [x] 로그아웃 시 cookie 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
