### PR TITLE
[fix] 쿠키 및 Security cors 설정 변경

### DIFF
--- a/src/main/java/vote/vote_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/vote/vote_be/domain/auth/controller/AuthController.java
@@ -37,9 +37,9 @@ public class AuthController {
         var cookie = CookieUtil.buildRefreshCookie(
                 result.getRefreshToken(),
                 result.getRefreshTtlSec(),
-                "",
-                false,
-                "LAX"
+                null,
+                true,
+                "None"
         );
         response.addHeader("Set-Cookie", cookie.toString());
 
@@ -52,9 +52,9 @@ public class AuthController {
     public ApiResponse<SimpleMessageDTO> logout(HttpServletRequest request, HttpServletResponse response) {
 
         var del = CookieUtil.deleteRefreshCookie(
-                "",
-                false,
-                "Lax"
+                null,
+                true,
+                "None"
         );
         response.addHeader("Set-Cookie", del.toString());
 

--- a/src/main/java/vote/vote_be/global/config/SecurityConfig.java
+++ b/src/main/java/vote/vote_be/global/config/SecurityConfig.java
@@ -63,11 +63,12 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:8080","http://localhost:3000")); // 로컬 도메인 허용(나중에 프론트 도메인으로 교체 필요)
+        configuration.setAllowedOrigins(List.of("http://localhost:8080","http://localhost:3000","https://vote-fe-mu.vercel.app")); // 로컬 도메인 허용(나중에 프론트 도메인으로 교체 필요)
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true); // 쿠키 인증 정보 허용
         configuration.addExposedHeader("Authorization");
+        configuration.addExposedHeader("Set-Cookie");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #23

## 📝작업 내용

> 프론트엔드와의 통신을 위해 쿠키와 Security.config의 cors 설정을 변경

- [x] 쿠키의 secure 설정 및 sameSite 변경
- [x] Security.config의 cors 설정 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
